### PR TITLE
fieldEditorのswitchの紐づけと解除の方法を変更しました。

### DIFF
--- a/SEED/Game/Objects/FieldObject/Door/FieldObject_Door.cpp
+++ b/SEED/Game/Objects/FieldObject/Door/FieldObject_Door.cpp
@@ -146,3 +146,11 @@ void FieldObject_Door::SetSwitch(FieldObject_Switch* pSwitch){
     }
     hasSwitch_ = true;
 }
+
+void FieldObject_Door::RemoveSwitch(FieldObject_Switch* pSwitch){
+    FieldObject_Switch* switchObj = pSwitch;
+    if (switchObj){
+        switchObj->UnregisterObserver(this);
+    }
+    hasSwitch_ = false;
+}

--- a/SEED/Game/Objects/FieldObject/Door/FieldObject_Door.h
+++ b/SEED/Game/Objects/FieldObject/Door/FieldObject_Door.h
@@ -29,19 +29,17 @@ public:
     // IObserver の実装
     void OnNotify(const std::string& event, void* data = nullptr) override;
 
-    //--- getter / setter ---//
-    bool GetIsOpened() const{ return isOpened_; }
-    void SetIsOpened(bool isOpened);
-
     // 状態変更用メソッド
     void ChangeState(DoorState* newState);
 
-    // 状態クラスからアクセスするためのメソッド
+    // --- getter / setter --- //
+    bool GetIsOpened() const{ return isOpened_; }
+    void SetIsOpened(bool isOpened);
     float GetOpenSpeed() const{ return openSpeed_; }
     float GetMaxOpenHeight() const{ return kMaxOpenHeight_; }
 
-    // --- getter / setter --- //
     void SetSwitch(FieldObject_Switch* pSwitch);
+    void RemoveSwitch(FieldObject_Switch* pSwitch);
     bool GetHasSwitch() const{ return hasSwitch_; }
 private:
     bool isOpened_ = false;                     // 開閉状態のフラグ

--- a/SEED/Game/Objects/FieldObject/Switch/FieldObject_Switch.cpp
+++ b/SEED/Game/Objects/FieldObject/Switch/FieldObject_Switch.cpp
@@ -106,6 +106,17 @@ void FieldObject_Switch::AddAssociatedDoor(FieldObject_Door* door){
     }
 }
 
+void FieldObject_Switch::RemoveAssociatedDoor(FieldObject_Door* door){
+    auto it = std::remove_if(
+        associatedDoors_.begin(),
+        associatedDoors_.end(),
+        [door] (FieldObject_Door* existingDoor){
+            return existingDoor == door;
+        }
+    );
+    associatedDoors_.erase(it, associatedDoors_.end());
+}
+
  std::vector<FieldObject_Door*>& FieldObject_Switch::GetAssociatedDoors(){
     return associatedDoors_;
 }

--- a/SEED/Game/Objects/FieldObject/Switch/FieldObject_Switch.h
+++ b/SEED/Game/Objects/FieldObject/Switch/FieldObject_Switch.h
@@ -31,6 +31,7 @@ public:
     //--- getter / setter ---//
     // ドアへのポインタを設定・取得するメソッド
     void AddAssociatedDoor(FieldObject_Door* door);
+    void RemoveAssociatedDoor(FieldObject_Door* door);
     std::vector<FieldObject_Door*>& GetAssociatedDoors();
 
     std::vector<IObserver*>& GetObservers(){ return observers_; }

--- a/SEED/resources/jsons/fieldModels/fieldModels.json
+++ b/SEED/resources/jsons/fieldModels/fieldModels.json
@@ -363,8 +363,7 @@
         },
         {
             "associatedDoors": [
-                1,
-                2
+                1
             ],
             "name": "switch",
             "position": [
@@ -404,27 +403,8 @@
             "type": 3
         },
         {
-            "name": "door",
-            "position": [
-                -5.0,
-                0.0,
-                -45.0
-            ],
-            "rotation": [
-                -0.0,
-                0.0,
-                0.0
-            ],
-            "scale": [
-                2.5,
-                2.5,
-                2.5
-            ],
-            "type": 3
-        },
-        {
             "associatedDoors": [
-                3
+                2
             ],
             "name": "switch",
             "position": [


### PR DESCRIPTION
スイッチを選択中にスクロールクリックで紐づけ、解除